### PR TITLE
bugfix gha

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Push Changes
       run: |


### PR DESCRIPTION
By default [actions/checkout@v4](https://github.com/actions/checkout/tree/v4/) fetches only the last commit. Replaced with 0 to 0 fetch all history for all branches and tags.